### PR TITLE
feat: Implement shields section

### DIFF
--- a/lib/models/shield.dart
+++ b/lib/models/shield.dart
@@ -1,0 +1,159 @@
+class ShieldStat {
+  final String name;
+  final num amount;
+
+  ShieldStat({
+    required this.name,
+    required this.amount,
+  });
+
+  factory ShieldStat.fromJson(Map<String, dynamic> json) {
+    return ShieldStat(
+      name: json['name'] ?? '',
+      amount: json['amount'] ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      'amount': amount,
+    };
+  }
+}
+
+class ShieldScaling {
+  final String name;
+  final String scaling;
+
+  ShieldScaling({
+    required this.name,
+    required this.scaling,
+  });
+
+  factory ShieldScaling.fromJson(Map<String, dynamic> json) {
+    return ShieldScaling(
+      name: json['name'] ?? '',
+      scaling: json['scaling'] ?? '-',
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      'scaling': scaling,
+    };
+  }
+}
+
+class Shield {
+  final String id;
+  final String name;
+  final String? description;
+  final String? image;
+  final String? category;
+  final double? weight;
+  final List<ShieldStat> attack;
+  final List<ShieldStat> defence;
+  final List<ShieldScaling> scalesWith;
+  final List<ShieldStat> requiredAttributes;
+
+  Shield({
+    required this.id,
+    required this.name,
+    this.description,
+    this.image,
+    this.category,
+    this.weight,
+    required this.attack,
+    required this.defence,
+    required this.scalesWith,
+    required this.requiredAttributes,
+  });
+
+  factory Shield.fromJson(Map<String, dynamic> json) {
+    return Shield(
+      id: json['id'] ?? '',
+      name: json['name'] ?? '',
+      description: json['description'],
+      image: json['image'],
+      category: json['category'],
+      weight: (json['weight'] as num?)?.toDouble(),
+      attack: json['attack'] != null
+          ? (json['attack'] as List).map((item) => ShieldStat.fromJson(item)).toList()
+          : [],
+      defence: json['defence'] != null
+          ? (json['defence'] as List).map((item) => ShieldStat.fromJson(item)).toList()
+          : [],
+      scalesWith: json['scalesWith'] != null
+          ? (json['scalesWith'] as List).map((item) => ShieldScaling.fromJson(item)).toList()
+          : [],
+      requiredAttributes: json['requiredAttributes'] != null
+          ? (json['requiredAttributes'] as List).map((item) => ShieldStat.fromJson(item)).toList()
+          : [],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'description': description,
+      'image': image,
+      'category': category,
+      'weight': weight,
+      'attack': attack.map((item) => item.toJson()).toList(),
+      'defence': defence.map((item) => item.toJson()).toList(),
+      'scalesWith': scalesWith.map((item) => item.toJson()).toList(),
+      'requiredAttributes': requiredAttributes.map((item) => item.toJson()).toList(),
+    };
+  }
+
+  // Métodos de utilidad
+  num get physicalAttack {
+    return attack.firstWhere((stat) => stat.name == 'Phy', orElse: () => ShieldStat(name: 'Phy', amount: 0)).amount;
+  }
+
+  num get criticalAttack {
+    return attack.firstWhere((stat) => stat.name == 'Crit', orElse: () => ShieldStat(name: 'Crit', amount: 100)).amount;
+  }
+
+  String get primaryScaling {
+    if (scalesWith.isEmpty) return '-';
+
+    // Encontrar el mejor escalado (A > B > C > D > E)
+    var bestScaling = scalesWith.first;
+    for (var scaling in scalesWith) {
+      if (_getScalingValue(scaling.scaling) > _getScalingValue(bestScaling.scaling)) {
+        bestScaling = scaling;
+      }
+    }
+
+    return '${bestScaling.name}: ${bestScaling.scaling}';
+  }
+
+  int _getScalingValue(String scaling) {
+    switch (scaling.toUpperCase()) {
+      case 'S': return 6;
+      case 'A': return 5;
+      case 'B': return 4;
+      case 'C': return 3;
+      case 'D': return 2;
+      case 'E': return 1;
+      default: return 0;
+    }
+  }
+
+  String get requiredStats {
+    if (requiredAttributes.isEmpty) return 'Ninguno';
+
+    List<String> requirements = [];
+    for (var attr in requiredAttributes) {
+      if (attr.amount > 0) {
+        requirements.add('${attr.name}: ${attr.amount}');
+      }
+    }
+
+    return requirements.isNotEmpty ? requirements.join(', ') : 'Ninguno';
+  }
+}

--- a/lib/screens/arsenal_screen.dart
+++ b/lib/screens/arsenal_screen.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import '../models/weapon.dart';
+import '../models/shield.dart';
+import '../utils/app_theme.dart';
+import 'weapons_screen.dart';
+import 'shields_screen.dart';
+
+class ArsenalScreen extends StatefulWidget {
+  final List<Weapon> weapons;
+  final List<Shield> shields;
+
+  const ArsenalScreen({
+    super.key,
+    required this.weapons,
+    required this.shields,
+  });
+
+  @override
+  State<ArsenalScreen> createState() => _ArsenalScreenState();
+}
+
+class _ArsenalScreenState extends State<ArsenalScreen> with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(
+          'Arsenal',
+          style: TextStyle(
+            color: AppTheme.primaryColor,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.pop(context),
+        ),
+        bottom: TabBar(
+          controller: _tabController,
+          labelColor: AppTheme.primaryColor,
+          unselectedLabelColor: AppTheme.textSecondaryColor,
+          indicatorColor: AppTheme.primaryColor,
+          tabs: const [
+            Tab(icon: Icon(Icons.construction), text: 'Armas'),
+            Tab(icon: Icon(Icons.shield), text: 'Escudos'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          WeaponsScreen(weapons: widget.weapons),
+          ShieldsScreen(shields: widget.shields),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/main_screen.dart
+++ b/lib/screens/main_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/boss.dart';
 import '../models/weapon.dart';
+import '../models/shield.dart';
 import '../models/item.dart';
 import '../models/zone.dart';
 import '../models/mission.dart';
@@ -52,6 +53,7 @@ class _MainScreenState extends State<MainScreen> {
         final bossCount = (gameData['bosses'] as List).length;
         final zoneCount = (gameData['zones'] as Map).length;
         final weaponCount = (gameData['weapons'] as List).length;
+        final shieldCount = (gameData['shields'] as List).length;
         final itemCount = (gameData['items'] as List).length;
         final locationCount = (gameData['locations'] as List).length;
         
@@ -59,6 +61,7 @@ class _MainScreenState extends State<MainScreen> {
         print('   🗡️ Jefes: $bossCount');
         print('   🗺️ Zonas: $zoneCount');
         print('   ⚔️ Armas: $weaponCount');
+        print('   🛡️ Escudos: $shieldCount');
         print('   📦 Objetos: $itemCount');
         print('   📍 Ubicaciones: $locationCount');
       }
@@ -90,6 +93,7 @@ class _MainScreenState extends State<MainScreen> {
       bosses: _gameData!['bosses'] as List<Boss>, // Ahora incluye todos los jefes
       prologoBosses: _gameData!['prologoBosses'] as List<Boss>,
       weapons: _gameData!['weapons'] as List<Weapon>,
+      shields: _gameData!['shields'] as List<Shield>,
       items: _gameData!['items'] as List<Item>,
       missions: _gameData!['missions'] ?? <Mission>[],
       locations: _castLocations(_gameData!['locations']),

--- a/lib/screens/shield_detail_screen.dart
+++ b/lib/screens/shield_detail_screen.dart
@@ -1,0 +1,505 @@
+import 'package:flutter/material.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import '../models/shield.dart';
+import '../utils/app_theme.dart';
+
+class ShieldDetailScreen extends StatelessWidget {
+  final Shield shield;
+
+  const ShieldDetailScreen({
+    super.key,
+    required this.shield,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          shield.name,
+          style: const TextStyle(
+            color: AppTheme.primaryColor,
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back),
+          onPressed: () => Navigator.pop(context),
+        ),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // Imagen del escudo
+            if (shield.image != null) ...[
+              Center(
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(12),
+                  child: CachedNetworkImage(
+                    imageUrl: shield.image!,
+                    height: 200,
+                    fit: BoxFit.contain,
+                    placeholder: (context, url) => Container(
+                      height: 200,
+                      decoration: BoxDecoration(
+                        color: AppTheme.surfaceColor,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: const Center(
+                        child: CircularProgressIndicator(
+                          color: AppTheme.primaryColor,
+                        ),
+                      ),
+                    ),
+                    errorWidget: (context, url, error) => Container(
+                      height: 200,
+                      decoration: BoxDecoration(
+                        color: AppTheme.surfaceColor,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: const Center(
+                        child: Icon(
+                          Icons.error,
+                          color: AppTheme.textSecondaryColor,
+                          size: 48,
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24),
+            ],
+
+            // Nombre y categoría
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    shield.name,
+                    style: const TextStyle(
+                      fontSize: 28,
+                      fontWeight: FontWeight.bold,
+                      color: AppTheme.primaryColor,
+                    ),
+                  ),
+                ),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: _getCategoryColor(shield.category),
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  child: Text(
+                    shield.category ?? 'Sin categoría',
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 14,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+
+            // Descripción
+            if (shield.description != null) ...[
+              Text(
+                shield.description!,
+                style: const TextStyle(
+                  fontSize: 16,
+                  color: AppTheme.textColor,
+                  height: 1.5,
+                ),
+              ),
+              const SizedBox(height: 24),
+            ],
+
+            // Stats de ataque
+            _buildStatsSection(
+              'Poder de Ataque',
+              shield.attack,
+              Icons.whatshot,
+              Colors.red,
+            ),
+            const SizedBox(height: 20),
+
+            // Stats de defensa
+            _buildStatsSection(
+              'Defensa/Resistencia',
+              shield.defence,
+              Icons.shield,
+              Colors.blue,
+            ),
+            const SizedBox(height: 20),
+
+            // Escalado de atributos
+            _buildScalingSection(),
+            const SizedBox(height: 20),
+
+            // Requisitos
+            _buildRequirementsSection(),
+            const SizedBox(height: 20),
+
+            // Información adicional
+            if (shield.weight != null) ...[
+              _buildInfoSection(),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStatsSection(String title, List<ShieldStat> stats, IconData icon, Color color) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(icon, color: color, size: 24),
+            const SizedBox(width: 8),
+            Text(
+              title,
+              style: TextStyle(
+                color: color,
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: AppTheme.surfaceColor,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: AppTheme.backgroundColor),
+          ),
+          child: Column(
+            children: stats.map((stat) => _buildStatRow(stat, color)).toList(),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildStatRow(ShieldStat stat, Color color) {
+    final String displayName = _getStatDisplayName(stat.name);
+    final double percentage = (stat.amount as num).toDouble() / 150.0; // Normalizamos a 150 como máximo típico
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 4),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 80,
+            child: Text(
+              displayName,
+              style: const TextStyle(
+                color: AppTheme.textColor,
+                fontSize: 14,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Stack(
+              children: [
+                Container(
+                  height: 20,
+                  decoration: BoxDecoration(
+                    color: AppTheme.backgroundColor,
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                ),
+                FractionallySizedBox(
+                  widthFactor: percentage.clamp(0.0, 1.0),
+                  child: Container(
+                    height: 20,
+                    decoration: BoxDecoration(
+                      color: color.withOpacity(0.8),
+                      borderRadius: BorderRadius.circular(10),
+                    ),
+                  ),
+                ),
+                Positioned.fill(
+                  child: Center(
+                    child: Text(
+                      '${stat.amount}',
+                      style: const TextStyle(
+                        color: Colors.white,
+                        fontSize: 12,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildScalingSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.trending_up, color: AppTheme.primaryColor, size: 24),
+            const SizedBox(width: 8),
+            const Text(
+              'Escalado de Atributos',
+              style: TextStyle(
+                color: AppTheme.primaryColor,
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: AppTheme.surfaceColor,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: AppTheme.backgroundColor),
+          ),
+          child: shield.scalesWith.isNotEmpty
+              ? Wrap(
+                  spacing: 12,
+                  runSpacing: 8,
+                  children: shield.scalesWith.map((scaling) => _buildScalingChip(scaling)).toList(),
+                )
+              : const Center(
+                  child: Text(
+                    'Sin escalado de atributos',
+                    style: TextStyle(
+                      color: AppTheme.textSecondaryColor,
+                      fontSize: 14,
+                    ),
+                  ),
+                ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildScalingChip(ShieldScaling scaling) {
+    final Color color = _getScalingColor(scaling.scaling);
+    final String displayName = _getStatDisplayName(scaling.name);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: color),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            displayName,
+            style: TextStyle(
+              color: color,
+              fontSize: 14,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(width: 6),
+          Container(
+            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+            decoration: BoxDecoration(
+              color: color,
+              borderRadius: BorderRadius.circular(6),
+            ),
+            child: Text(
+              scaling.scaling,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 12,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRequirementsSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.assignment, color: Colors.orange, size: 24),
+            const SizedBox(width: 8),
+            const Text(
+              'Requisitos de Atributos',
+              style: TextStyle(
+                color: Colors.orange,
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: AppTheme.surfaceColor,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: AppTheme.backgroundColor),
+          ),
+          child: shield.requiredAttributes.isNotEmpty
+              ? Wrap(
+                  spacing: 12,
+                  runSpacing: 8,
+                  children: shield.requiredAttributes
+                      .where((req) => req.amount > 0)
+                      .map((req) => _buildRequirementChip(req))
+                      .toList(),
+                )
+              : const Center(
+                  child: Text(
+                    'Sin requisitos especiales',
+                    style: TextStyle(
+                      color: AppTheme.textSecondaryColor,
+                      fontSize: 14,
+                    ),
+                  ),
+                ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildRequirementChip(ShieldStat requirement) {
+    final String displayName = _getStatDisplayName(requirement.name);
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: Colors.orange.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: Colors.orange),
+      ),
+      child: Text(
+        '$displayName: ${requirement.amount}',
+        style: const TextStyle(
+          color: Colors.orange,
+          fontSize: 14,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.info, color: Colors.grey, size: 24),
+            const SizedBox(width: 8),
+            const Text(
+              'Información Adicional',
+              style: TextStyle(
+                color: Colors.grey,
+                fontSize: 20,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Container(
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: AppTheme.surfaceColor,
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: AppTheme.backgroundColor),
+          ),
+          child: Row(
+            children: [
+              Icon(Icons.fitness_center, color: Colors.grey, size: 20),
+              const SizedBox(width: 8),
+              const Text(
+                'Peso:',
+                style: TextStyle(
+                  color: AppTheme.textColor,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                '${shield.weight!.toStringAsFixed(1)} unidades',
+                style: const TextStyle(
+                  color: AppTheme.textColor,
+                  fontSize: 16,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _getStatDisplayName(String stat) {
+    switch (stat.toLowerCase()) {
+      case 'phy': return 'Físico';
+      case 'mag': return 'Mágico';
+      case 'fire': return 'Fuego';
+      case 'ligt': return 'Rayo';
+      case 'holy': return 'Sagrado';
+      case 'crit': return 'Crítico';
+      case 'boost': return 'Boost';
+      case 'str': return 'Fuerza';
+      case 'dex': return 'Destreza';
+      case 'int': return 'Inteligencia';
+      case 'fai': return 'Fe';
+      case 'arc': return 'Arcano';
+      default: return stat;
+    }
+  }
+
+  Color _getScalingColor(String scaling) {
+    switch (scaling.toUpperCase()) {
+      case 'S': return const Color(0xFFFF6B00); // Naranja brillante
+      case 'A': return const Color(0xFF4CAF50); // Verde
+      case 'B': return const Color(0xFF2196F3); // Azul
+      case 'C': return const Color(0xFFFF9800); // Naranja
+      case 'D': return const Color(0xFF9E9E9E); // Gris
+      case 'E': return const Color(0xFF616161); // Gris oscuro
+      default: return Colors.grey;
+    }
+  }
+
+  Color _getCategoryColor(String? category) {
+    switch (category?.toLowerCase()) {
+      case 'escudo pequeño':
+        return Colors.green;
+      case 'escudo mediano':
+        return Colors.blue;
+      case 'gran escudo':
+        return Colors.purple;
+      default:
+        return Colors.grey;
+    }
+  }
+}

--- a/lib/screens/shields_screen.dart
+++ b/lib/screens/shields_screen.dart
@@ -1,46 +1,47 @@
 import 'package:flutter/material.dart';
-import '../models/weapon.dart';
+import '../models/shield.dart';
 import '../utils/app_theme.dart';
-import 'weapon_detail_screen.dart';
+import 'shield_detail_screen.dart';
 
-class WeaponsScreen extends StatefulWidget {
-  final List<Weapon> weapons;
+class ShieldsScreen extends StatefulWidget {
+  final List<Shield> shields;
 
-  const WeaponsScreen({
+  const ShieldsScreen({
     super.key,
-    required this.weapons,
+    required this.shields,
   });
 
   @override
-  State<WeaponsScreen> createState() => _WeaponsScreenState();
+  State<ShieldsScreen> createState() => _ShieldsScreenState();
 }
 
-class _WeaponsScreenState extends State<WeaponsScreen> {
-  List<Weapon> _filteredWeapons = [];
+class _ShieldsScreenState extends State<ShieldsScreen> {
+  List<Shield> _filteredShields = [];
   String _searchQuery = '';
   String? _selectedCategory;
-  
+
   @override
   void initState() {
     super.initState();
-    _filteredWeapons = widget.weapons;
+    _filteredShields = widget.shields;
   }
 
-  void _filterWeapons() {
+  void _filterShields() {
     setState(() {
-      _filteredWeapons = widget.weapons.where((weapon) {
-        bool matchesSearch = weapon.name.toLowerCase().contains(_searchQuery.toLowerCase());
-        bool matchesCategory = _selectedCategory == null || weapon.category == _selectedCategory;
+      _filteredShields = widget.shields.where((shield) {
+        bool matchesSearch = shield.name.toLowerCase().contains(_searchQuery.toLowerCase());
+        bool matchesCategory = _selectedCategory == null || shield.category == _selectedCategory;
         return matchesSearch && matchesCategory;
       }).toList();
-      
-      // Ordenar por ataque físico descendente
-      _filteredWeapons.sort((a, b) => b.physicalAttack.compareTo(a.physicalAttack));
+
+      // Ordenar por defensa física descendente
+      _filteredShields.sort((a, b) => (b.defence.firstWhere((element) => element.name == 'Phy').amount as int)
+          .compareTo((a.defence.firstWhere((element) => element.name == 'Phy').amount as int)));
     });
   }
 
   Set<String> get _availableCategories {
-    return widget.weapons.map((weapon) => weapon.category ?? 'Sin categoría').toSet();
+    return widget.shields.map((shield) => shield.category ?? 'Sin categoría').toSet();
   }
 
   @override
@@ -55,7 +56,7 @@ class _WeaponsScreenState extends State<WeaponsScreen> {
               // Barra de búsqueda
               TextField(
                 decoration: InputDecoration(
-                  hintText: 'Buscar armas...',
+                  hintText: 'Buscar escudos...',
                   prefixIcon: const Icon(Icons.search, color: AppTheme.primaryColor),
                   border: OutlineInputBorder(
                     borderRadius: BorderRadius.circular(12),
@@ -71,7 +72,7 @@ class _WeaponsScreenState extends State<WeaponsScreen> {
                 style: const TextStyle(color: AppTheme.textColor),
                 onChanged: (value) {
                   _searchQuery = value;
-                  _filterWeapons();
+                  _filterShields();
                 },
               ),
               const SizedBox(height: 12),
@@ -95,7 +96,7 @@ class _WeaponsScreenState extends State<WeaponsScreen> {
                         setState(() {
                           _selectedCategory = value;
                         });
-                        _filterWeapons();
+                        _filterShields();
                       },
                       items: [
                         const DropdownMenuItem<String?>(
@@ -122,14 +123,14 @@ class _WeaponsScreenState extends State<WeaponsScreen> {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text(
-                '${_filteredWeapons.length} armas encontradas',
+                '${_filteredShields.length} escudos encontrados',
                 style: const TextStyle(
                   color: AppTheme.textSecondaryColor,
                   fontSize: 14,
                 ),
               ),
               Text(
-                'Ordenado por daño',
+                'Ordenado por defensa',
                 style: const TextStyle(
                   color: AppTheme.textSecondaryColor,
                   fontSize: 14,
@@ -141,14 +142,14 @@ class _WeaponsScreenState extends State<WeaponsScreen> {
 
         const SizedBox(height: 8),
 
-        // Lista de armas
+        // Lista de escudos
         Expanded(
           child: ListView.builder(
             padding: const EdgeInsets.all(16),
-            itemCount: _filteredWeapons.length,
+            itemCount: _filteredShields.length,
             itemBuilder: (context, index) {
-              final weapon = _filteredWeapons[index];
-              return _buildWeaponCard(weapon);
+              final shield = _filteredShields[index];
+              return _buildShieldCard(shield);
             },
           ),
         ),
@@ -156,17 +157,17 @@ class _WeaponsScreenState extends State<WeaponsScreen> {
     );
   }
 
-  Widget _buildWeaponCard(Weapon weapon) {
+  Widget _buildShieldCard(Shield shield) {
     return Card(
       margin: const EdgeInsets.only(bottom: 12),
       child: InkWell(
-        onTap: () => _navigateToWeaponDetail(weapon),
+        onTap: () => _navigateToShieldDetail(shield),
         borderRadius: BorderRadius.circular(12),
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Row(
             children: [
-              // Ícono del arma por categoría
+              // Ícono del escudo por categoría
               Container(
                 width: 50,
                 height: 50,
@@ -175,14 +176,14 @@ class _WeaponsScreenState extends State<WeaponsScreen> {
                   borderRadius: BorderRadius.circular(8),
                 ),
                 child: Icon(
-                  _getWeaponIcon(weapon.category),
+                  _getShieldIcon(shield.category),
                   color: AppTheme.primaryColor,
                   size: 28,
                 ),
               ),
-              
+
               const SizedBox(width: 16),
-              
+
               // Información principal
               Expanded(
                 child: Column(
@@ -192,7 +193,7 @@ class _WeaponsScreenState extends State<WeaponsScreen> {
                       children: [
                         Expanded(
                           child: Text(
-                            weapon.name,
+                            shield.name,
                             style: const TextStyle(
                               fontSize: 18,
                               fontWeight: FontWeight.bold,
@@ -204,11 +205,11 @@ class _WeaponsScreenState extends State<WeaponsScreen> {
                         Container(
                           padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
                           decoration: BoxDecoration(
-                            color: _getCategoryColor(weapon.category),
+                            color: _getCategoryColor(shield.category),
                             borderRadius: BorderRadius.circular(12),
                           ),
                           child: Text(
-                            weapon.category ?? 'Sin categoría',
+                            shield.category ?? 'Sin categoría',
                             style: const TextStyle(
                               color: Colors.white,
                               fontSize: 11,
@@ -219,23 +220,20 @@ class _WeaponsScreenState extends State<WeaponsScreen> {
                       ],
                     ),
                     const SizedBox(height: 8),
-                    
+
                     // Stats principales
                     Row(
                       children: [
-                        _buildStatChip('⚔️ ${weapon.physicalAttack}', Colors.red),
+                        _buildStatChip('🛡️ ${shield.defence.firstWhere((stat) => stat.name == 'Phy').amount}', Colors.blue),
                         const SizedBox(width: 8),
-                        _buildStatChip('📊 ${weapon.primaryScaling}', Colors.blue),
-                        const SizedBox(width: 8),
-                        if (weapon.weight != null)
-                          _buildStatChip('⚖️ ${weapon.weight!.toStringAsFixed(1)}', Colors.grey),
+                        _buildStatChip('⚖️ ${shield.weight?.toStringAsFixed(1)}', Colors.grey),
                       ],
                     ),
                     const SizedBox(height: 8),
-                    
+
                     // Requisitos
                     Text(
-                      'Requisitos: ${weapon.requiredStats}',
+                      'Requisitos: ${shield.requiredStats}',
                       style: const TextStyle(
                         color: AppTheme.textSecondaryColor,
                         fontSize: 12,
@@ -245,9 +243,9 @@ class _WeaponsScreenState extends State<WeaponsScreen> {
                   ],
                 ),
               ),
-              
+
               const SizedBox(width: 8),
-              
+
               // Flecha de navegación
               const Icon(
                 Icons.arrow_forward_ios,
@@ -279,48 +277,38 @@ class _WeaponsScreenState extends State<WeaponsScreen> {
     );
   }
 
-  IconData _getWeaponIcon(String? category) {
+  IconData _getShieldIcon(String? category) {
     switch (category?.toLowerCase()) {
-      case 'espada recta':
-      case 'espada':
-        return Icons.construction;
-      case 'hacha':
-        return Icons.hardware;
-      case 'lanza':
-        return Icons.grain;
-      case 'arco':
-        return Icons.tune;
-      case 'bastón':
-        return Icons.timeline;
+      case 'escudo pequeño':
+        return Icons.shield_outlined;
+      case 'escudo mediano':
+        return Icons.shield;
+      case 'gran escudo':
+        return Icons.security;
       default:
-        return Icons.sports_esports;
+        return Icons.shield;
     }
   }
 
   Color _getCategoryColor(String? category) {
     switch (category?.toLowerCase()) {
-      case 'espada recta':
-      case 'espada':
-        return Colors.blue;
-      case 'hacha':
-        return Colors.orange;
-      case 'lanza':
+      case 'escudo pequeño':
         return Colors.green;
-      case 'arco':
+      case 'escudo mediano':
+        return Colors.blue;
+      case 'gran escudo':
         return Colors.purple;
-      case 'bastón':
-        return Colors.indigo;
       default:
         return Colors.grey;
     }
   }
 
-  void _navigateToWeaponDetail(Weapon weapon) {
+  void _navigateToShieldDetail(Shield shield) {
     Navigator.push(
       context,
       PageRouteBuilder(
-        pageBuilder: (context, animation, secondaryAnimation) => WeaponDetailScreen(
-          weapon: weapon,
+        pageBuilder: (context, animation, secondaryAnimation) => ShieldDetailScreen(
+          shield: shield,
         ),
         transitionsBuilder: (context, animation, secondaryAnimation, child) {
           const begin = Offset(1.0, 0.0);
@@ -344,4 +332,3 @@ class _WeaponsScreenState extends State<WeaponsScreen> {
     );
   }
 }
-

--- a/lib/screens/zones_screen.dart
+++ b/lib/screens/zones_screen.dart
@@ -2,19 +2,21 @@ import 'package:flutter/material.dart';
 import '../models/zone.dart';
 import '../models/boss.dart';
 import '../models/weapon.dart';
+import '../models/shield.dart';
 import '../models/item.dart';
 import '../models/mission.dart';
 import '../services/progress_service.dart';
 import '../services/auth_service.dart';
 import '../utils/app_theme.dart';
 import 'zone_detail_screen.dart';
-import 'weapons_screen.dart';
+import 'arsenal_screen.dart';
 
 class ZonesScreen extends StatefulWidget {
   final Map<String, Zone> zones;
   final List<Boss> bosses;
   final List<Boss> prologoBosses;
   final List<Weapon> weapons;
+  final List<Shield> shields;
   final List<Item> items;
   final List<Mission> missions;
   final List<Map<String, dynamic>> locations;
@@ -26,6 +28,7 @@ class ZonesScreen extends StatefulWidget {
     required this.bosses,
     required this.prologoBosses,
     required this.weapons,
+    required this.shields,
     required this.items,
     required this.missions,
     required this.locations,
@@ -435,7 +438,7 @@ class _ZonesScreenState extends State<ZonesScreen>
                 const SizedBox(width: 12),
                 Expanded(
                   child: ElevatedButton.icon(
-                    onPressed: () => _navigateToAllWeapons(),
+                    onPressed: () => _navigateToArsenal(),
                     icon: const Icon(Icons.construction),
                     label: const Text('Arsenal'),
                     style: ElevatedButton.styleFrom(
@@ -813,12 +816,13 @@ class _ZonesScreenState extends State<ZonesScreen>
     return levelRanges[levelText];
   }
 
-  void _navigateToAllWeapons() {
+  void _navigateToArsenal() {
     Navigator.push(
       context,
       PageRouteBuilder(
-        pageBuilder: (context, animation, secondaryAnimation) => WeaponsScreen(
+        pageBuilder: (context, animation, secondaryAnimation) => ArsenalScreen(
           weapons: widget.weapons,
+          shields: widget.shields,
         ),
         transitionsBuilder: (context, animation, secondaryAnimation, child) {
           const begin = Offset(1.0, 0.0);

--- a/lib/services/data_service.dart
+++ b/lib/services/data_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:flutter/services.dart';
 import '../models/boss.dart';
 import '../models/weapon.dart';
+import '../models/shield.dart';
 import '../models/item.dart';
 import '../models/zone.dart';
 import '../models/mission.dart';
@@ -38,6 +39,7 @@ class DataService {
       final items = _parseItems(futures[3]);
       final locations = futures[4];
       final regionsDifficulty = futures[5];
+      final shields = _parseShields(futures[10]);
       
       // Combinar todos los jefes
       final allBosses = [...bosses, ...prologoBosses];
@@ -51,13 +53,13 @@ class DataService {
         'weapons': weapons,
         'items': items,
         'zones': zones,
+        'shields': shields,
         'locations': locations,
         'regionsDifficulty': regionsDifficulty,
         'armors': futures[6],
         'talismans': futures[7],
         'spirits': futures[8],
         'sorceries': futures[9],
-        'shields': futures[10],
         'npcs': futures[11],
         'ashes': futures[12],
         'ammos': futures[13],
@@ -135,6 +137,15 @@ class DataService {
     
     return jsonData.map((json) {
       return Weapon.fromJson(json);
+    }).toList();
+  }
+
+  // Parsear escudos desde JSON
+  static List<Shield> _parseShields(dynamic jsonData) {
+    if (jsonData is! List) return [];
+
+    return jsonData.map((json) {
+      return Shield.fromJson(json);
     }).toList();
   }
 


### PR DESCRIPTION
This commit introduces a new shields section to the application.

- Adds a `Shield` model to represent shield data.
- Updates `DataService` to load shield data from `shields.es.json`.
- Creates a new `ShieldsScreen` to display a list of shields with filtering and searching capabilities.
- Creates a new `ShieldDetailScreen` to display the details of a selected shield.
- Creates a new `ArsenalScreen` with tabs for "Weapons" and "Shields".
- Updates the navigation to direct the "Arsenal" button to the new `ArsenalScreen`.
- Refactors `WeaponsScreen` to be displayed as a tab within the `ArsenalScreen`.